### PR TITLE
Actualizar CSS para unidades de ventana gráfica y posicionamiento

### DIFF
--- a/frontend/src/app/dashboards/patient/history-appointments/history-appointments/history-appointments.component.css
+++ b/frontend/src/app/dashboards/patient/history-appointments/history-appointments/history-appointments.component.css
@@ -1,6 +1,6 @@
 /* ===== CONTENEDOR PRINCIPAL ===== */
 .history-container {
-    max-width: 100vw;
+    max-width: 100dvw;
     margin: 0 auto;
     background: #f8f9fa;
     min-height: 100vh;

--- a/frontend/src/app/pages/auth/register/register.component.css
+++ b/frontend/src/app/pages/auth/register/register.component.css
@@ -13,7 +13,7 @@
   box-shadow: inset 0 0 0 200vw rgba(0, 0, 0, 0.1);
   min-height: 100vh;
   width: 100vw;
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   margin: 0;
@@ -22,8 +22,6 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
-  /* ✅ Animación más rápida del contenedor */
   animation: containerFadeIn 0.6s ease-out;
 }
 
@@ -519,7 +517,7 @@ input:focus::placeholder {
   }
 
   .register-container {
-    position: fixed;
+    position: absolute;
     min-height: 100vh;
     width: 100vw;
     left: 0;
@@ -640,7 +638,7 @@ input:focus::placeholder {
 }
 
 /* ✅ Para pantallas horizontales - animaciones ultra rápidas */
-@media screen and (max-height: 700px) and (orientation: landscape) {
+@media screen and (max-height: 800px) and (orientation: landscape) {
   .register-container { animation-duration: 0.2s; }
   h2 { animation-duration: 0.2s; animation-delay: 0.05s; }
   form { animation-duration: 0.2s; animation-delay: 0.1s; }


### PR DESCRIPTION
Se ha sustituido «vw» por «dvw» en la anchura máxima del componente de citas del historial para mejorar la compatibilidad con las ventanas gráficas. Se han cambiado las posiciones de .register-container y .register-bg de fijas a absolutas, y se ha ajustado la consulta de medios para pantallas apaisadas a una altura máxima de 800px para mejorar la capacidad de respuesta del diseño.